### PR TITLE
removes os from use_cases

### DIFF
--- a/adapters.py
+++ b/adapters.py
@@ -1,36 +1,54 @@
 import json
 import os
+from abc import ABC, abstractmethod
 from dataclasses import asdict
 
 from entities import Project, Role, TimeEntry
 from errors import ProjectNotFoundError
 
 
-class ProjectFileRepository:
+class ProjectStorage(ABC):
+    """Abstract class for a project repository backend"""
+
+    @abstractmethod
+    def load(self, project_name: str) -> Project:
+        """Load a project by name"""
+
+    @abstractmethod
+    def save(self, project) -> None:
+        """Save a project"""
+
+    @abstractmethod
+    def exists(self, project_name: str) -> bool:
+        """Check if a project exists"""
+
+
+class ProjectFileStorage(ProjectStorage):
     def __init__(self, base_path):
         if not os.path.exists(base_path):
             os.makedirs(base_path)
         self.base_path = base_path
 
-    def path(self, project_name):
+    def path(self, project_name: str) -> str:
         return f"{self.base_path}/{project_name}.json"
 
-    def load(self, project_name) -> Project:
-        project_path = self.path(project_name)
-
-        if os.path.exists(project_path):
-            with open(project_path, "r") as f:
+    def load(self, project_name: str) -> Project:
+        if self.exists(project_name):
+            with open(self.path(project_name), "r") as f:
                 project_dict = json.load(f)
             return self._load_objects(project_dict)
         else:
             raise ProjectNotFoundError(project_name)
 
-    def save(self, project):
+    def save(self, project: Project) -> None:
         project_path = self.path(project.name)
         file_path = os.path.join(os.getcwd(), project_path)
 
         with open(file_path, "w") as f:
             json.dump(asdict(project), f, indent=4)
+
+    def exists(self, project_name: str) -> bool:
+        return os.path.exists(self.path(project_name))
 
     def _load_objects(self, project_dict: dict) -> Project:
         project = Project(**project_dict)

--- a/devbox.json
+++ b/devbox.json
@@ -7,7 +7,7 @@
     "ruff@latest"
   ],
   "shell": {
-    "init_hook": ["echo 'Welcome to devbox!' > /dev/null"],
+    "init_hook": ["fish $VENV_DIR/bin/activate.fish"],
     "scripts": {
       "test": ["python -m unittest"],
       "clean": ["nix store gc"]

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from use_cases import InitializeProjectWizard, SummarizeTime, ToggleTrackingInte
 
 class CommandLineInterface:
     def __init__(self):
-        self.project_repo = ProjectFileStorage(".timekeeper")
+        self.project_storage = ProjectFileStorage(".timekeeper")
 
     def run(self):
         parser = argparse.ArgumentParser(description="Time tracking utility.")
@@ -52,13 +52,13 @@ class CommandLineInterface:
             parser.print_help()
 
     def init_project(self) -> None:
-        InitializeProjectWizard(self.project_repo).execute()
+        InitializeProjectWizard(self.project_storage).execute()
 
     def toggle_tracking(self, project_name: str, role_name: str = "") -> None:
-        ToggleTrackingInteractor(self.project_repo).execute(project_name, role_name)
+        ToggleTrackingInteractor(self.project_storage).execute(project_name, role_name)
 
     def summarize_time(self, period: str, project_name: str = "") -> None:
-        SummarizeTime(self.project_repo).execute(period, project_name)
+        SummarizeTime(self.project_storage).execute(period, project_name)
 
 
 def main():

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
 import argparse
 
-from adapters import ProjectFileRepository
+from adapters import ProjectFileStorage
 from use_cases import InitializeProjectWizard, SummarizeTime, ToggleTrackingInteractor
 
 
 class CommandLineInterface:
     def __init__(self):
-        self.project_repo = ProjectFileRepository(".timekeeper")
+        self.project_repo = ProjectFileStorage(".timekeeper")
 
     def run(self):
         parser = argparse.ArgumentParser(description="Time tracking utility.")
@@ -61,9 +61,13 @@ class CommandLineInterface:
         SummarizeTime(self.project_repo).execute(period, project_name)
 
 
-if __name__ == "__main__":
+def main():
     try:
         cli = CommandLineInterface()
         cli.run()
     except Exception as e:
         exit(str(e))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- implements a ProjectStorage abstract base class as a means to decouple the use_cases from the particular storage adapter that is used by the main loop
- refactors naming away from "repo" because that could be confusing